### PR TITLE
Clear margin_box before generating a new margin_box in go_to_page

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -312,6 +312,11 @@ module Prawn
     def go_to_page(k)
       @page_number = k
       state.page = state.pages[k-1]
+
+      # Clear existing margin as we don't want it to pass any existing padding
+      # into the new generated margin_box
+      @margin_box = nil
+
       generate_margin_box
       @bounding_box = @margin_box
       @y = @bounding_box.absolute_top


### PR DESCRIPTION
References https://github.com/GetSilverfin/silverfin/issues/2108

What happens is that inside an [indent](https://github.com/GetSilverfin/prawn/blob/tarmo-attempt-to-fix-padding-accumulation/lib/prawn/document/bounding_box.rb#L264) call [go_to_page](https://github.com/GetSilverfin/prawn/blob/tarmo-attempt-to-fix-padding-accumulation/lib/prawn/document.rb#L312) is called which also calls [generate_margin_box](https://github.com/GetSilverfin/prawn/blob/tarmo-attempt-to-fix-padding-accumulation/lib/prawn/document.rb#L702) that then attempts to maintain the indent settings from the existing `@margin_box` [here](https://github.com/GetSilverfin/prawn/blob/tarmo-attempt-to-fix-padding-accumulation/lib/prawn/document.rb#L716) (if one exists).

My change clears the `@margin_box` on a `go_to_page` call before generating a new margin box, this is based on the assumption that the existing `@margin_box` is not relevant to the target page. This fixes the indent accumulation issue.