### PR TITLE
Fix bounds consistency on float

### DIFF
--- a/lib/prawn/document.rb
+++ b/lib/prawn/document.rb
@@ -351,8 +351,12 @@ module Prawn
     def float
       original_page = page_number
       original_y = y
+      original_bb = @bounding_box
       yield
-      go_to_page(original_page) unless page_number == original_page
+      unless page_number == original_page
+        go_to_page(original_page)
+        self.bounds = original_bb if original_bb
+      end
       self.y = original_y
     end
 


### PR DESCRIPTION
This is necessary to ensure indent() is kept consistent on page changes.