### PR TITLE
Revert "Merge pull request #5 from GetSilverfin/tarmo-fix-bold-text-w.."

### DIFF
--- a/lib/prawn/core/text/formatted/line_wrap.rb
+++ b/lib/prawn/core/text/formatted/line_wrap.rb
@@ -93,8 +93,7 @@ module Prawn
                 if segment == zero_width_space
                   segment_width = 0
                 else
-                  style = @arranger.font_style(@arranger.current_format_state[:styles])
-                  segment_width = @document.width_of(segment, :kerning => @kerning, :style => style)
+                  segment_width = @document.width_of(segment, :kerning => @kerning)
                 end
 
                 if @accumulated_width + segment_width <= @width


### PR DESCRIPTION
This fix was actually wrong and the bug it was trying to fix was caused by dfont-related configuration issues.