### PR TITLE
Process soft-hyphens in blocks which do not exclude trailing white space

### DIFF
--- a/spec/line_wrap_spec.rb
+++ b/spec/line_wrap_spec.rb
@@ -128,25 +128,28 @@ describe "Core::Text::Formatted::LineWrap#wrap_line" do
     string.should == "hello#{Prawn::Text::SHY}"
   end
 
-  it "should not display soft hyphens except at the end of a line" do
-    string = @pdf.font.normalize_encoding("hello#{Prawn::Text::SHY}world")
-    array = [{ :text => string }]
+  it "should not display soft hyphens except at the end of a line " +
+     "for more than one element in format_array", :issue => 347 do
+    string1 = @pdf.font.normalize_encoding("hello#{Prawn::Text::SHY}world ")
+    string2 = @pdf.font.normalize_encoding("hi#{Prawn::Text::SHY}earth")
+    array = [{ :text => string1 }, { :text => string2 }]
     @arranger.format_array = array
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => 300,
                                   :document => @pdf)
-    string.should == "helloworld"
+    string.should == "helloworld hiearth"
 
     @pdf.font("#{Prawn::DATADIR}/fonts/DejaVuSans.ttf")
     @line_wrap = Prawn::Core::Text::Formatted::LineWrap.new
 
-    string = "hello#{Prawn::Text::SHY}world"
-    array = [{ :text => string }]
+    string1 = "hello#{Prawn::Text::SHY}world "
+    string2 = @pdf.font.normalize_encoding("hi#{Prawn::Text::SHY}earth")
+    array = [{ :text => string1 }, { :text => string2 }]
     @arranger.format_array = array
     string = @line_wrap.wrap_line(:arranger => @arranger,
                                   :width => 300,
                                   :document => @pdf)
-    string.should == "helloworld"
+    string.should == "helloworld hiearth"
   end
 
   it "should not break before a hard hyphen that follows a word" do


### PR DESCRIPTION
This commit was created by cherry picking this commit which
fixes a bug in how soft hypens are processed:
https://github.com/prawnpdf/prawn/commit/143371d7d5bcf791d80d7edf0f6cc40cc330d960

Note that there is a slight difference with that commit.
When resolving cherry pick conflicts I removed some logic
which was there to support ruby version 1.8. This is ok
because this was cleaned up in an earlier commit that's in
upstream: https://github.com/prawnpdf/prawn/commit/ce7147d80628009ff766e8283146d2a6d0da1bfa