### PR TITLE
Fix fallback font width sizes for zero width

### DIFF
--- a/lib/prawn/font/ttf.rb
+++ b/lib/prawn/font/ttf.rb
@@ -218,17 +218,17 @@ module Prawn
       def character_width_by_code(code)
         return 0 unless cmap[code]
 
+        # Some TTF fonts have nonzero widths for \n (UTF-8 / ASCII code: 10).
+        # Patch around this as we'll never be drawing a newline with a width.
+        return 0.0 if code == 10 || code == 13
+
         # If font can't find the specified code hmtx width returns the default
         # value that is not wide enough for all other characters to fit in.
         # Therefore, we are setting it to default value of "W" which is the
         # widest ASCII character (which all fonts have).
-        if cmap[code] == 0
+        if cmap.code_map[code].nil?
           code = 87 # code for W
         end
-
-        # Some TTF fonts have nonzero widths for \n (UTF-8 / ASCII code: 10).
-        # Patch around this as we'll never be drawing a newline with a width.
-        return 0.0 if code == 10 || code == 13
 
         @char_widths[code] ||= Integer(hmtx.widths[cmap[code]] * scale_factor)
       end


### PR DESCRIPTION
Zero width characters were being mistakenly selected
as if they were a missing character. This is because the
cmap function returns 0 when it's either a missing character
or some special characters like newline.