### PR TITLE
Fix bold styling with fallback_fonts

### DIFF
--- a/lib/prawn/text/formatted/box.rb
+++ b/lib/prawn/text/formatted/box.rb
@@ -143,7 +143,7 @@ module Prawn
         # Example (see Prawn::Text::Core::Formatted::Wrap for what is required
         # of the wrap method if you want to override the default wrapping
         # algorithm):
-        # 
+        #
         #
         #   module MyWrap
         #
@@ -283,7 +283,7 @@ module Prawn
         end
 
         # The height actually used during the previous <tt>render</tt>
-        # 
+        #
         def height
           return 0 if @baseline_y.nil? || @descender.nil?
           (@baseline_y - @descender).abs
@@ -379,33 +379,37 @@ module Prawn
 
           original_font = @document.font.family
           fragment_font = hash[:font] || original_font
-          @document.font(fragment_font)
 
           fallback_fonts = @fallback_fonts.dup
           # always default back to the current font if the glyph is missing from
           # all fonts
           fallback_fonts << fragment_font
 
-          hash[:text].unicode_characters do |char|
-            @document.font(fragment_font)
-            font_glyph_pairs << [find_font_for_this_glyph(char,
-                                                          @document.font.family,
-                                                          fallback_fonts.dup),
-                                 char]
+          @document.save_font do
+            hash[:text].each_char do |char|
+              font_glyph_pairs << [find_font_for_this_glyph(char,
+                                                            fragment_font,
+                                                            fallback_fonts.dup),
+                                   char]
+            end
           end
 
-          @document.font(original_font)
+          # Don't add a :font to fragments if it wasn't there originally
+          if hash[:font].nil?
+            font_glyph_pairs.each do |pair|
+              pair[0] = nil if pair[0] == original_font
+            end
+          end
 
           form_fragments_from_like_font_glyph_pairs(font_glyph_pairs, hash)
         end
 
         def find_font_for_this_glyph(char, current_font, fallback_fonts)
+          @document.font(current_font)
           if fallback_fonts.length == 0 || @document.font.glyph_present?(char)
             current_font
           else
-            current_font = fallback_fonts.shift
-            @document.font(current_font)
-            find_font_for_this_glyph(char, @document.font.family, fallback_fonts)
+            find_font_for_this_glyph(char, fallback_fonts.shift, fallback_fonts)
           end
         end
 
@@ -415,11 +419,11 @@ module Prawn
           current_font = nil
 
           font_glyph_pairs.each do |font, char|
-            if font != current_font
+            if font != current_font || fragments.count == 0
               current_font = font
               fragment = hash.dup
               fragment[:text] = char
-              fragment[:font] = font
+              fragment[:font] = font unless font.nil?
               fragments << fragment
             else
               fragment[:text] += char
@@ -554,7 +558,7 @@ module Prawn
           if underline
             @document.stroke_line(fragment.underline_points)
           end
-          
+
           strikethrough = fragment.styles.include?(:strikethrough)
           if strikethrough
             @document.stroke_line(fragment.strikethrough_points)

--- a/spec/text_spec.rb
+++ b/spec/text_spec.rb
@@ -427,4 +427,22 @@ describe "#text" do
       @pdf.text "VAT", :kerning => false
     end
   end
+
+  describe "fallback_fonts" do
+    it "should preserve font style" do
+      create_pdf
+
+      @pdf.fallback_fonts ["Helvetica"]
+      @pdf.font "Times-Roman", :style => :italic do
+        @pdf.text "hello"
+      end
+
+      text = PDF::Inspector::Text.analyze(@pdf.render)
+      fonts_used = text.font_settings.map { |e| e[:name] }
+
+      fonts_used.length.should == 1
+      fonts_used[0].should == :"Times-Italic"
+      text.strings[0].should == "hello"
+    end
+  end
 end


### PR DESCRIPTION
This is a cherry-pick of
https://github.com/prawnpdf/prawn/pull/743/commits/d49017b99878a492e8593e24c0defbdc25264111

Original commit message:

```
Don’t set font on fragments without font when processing fallback #263
```