### PR TITLE
Fix a bug where a cell under colspan would be broken

### DIFF
--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -1293,6 +1293,20 @@ describe "colspan / rowspan" do
     heights[0].should == heights[1]
   end
 
+  it "doesn't make a large column below colspan smaller" do
+    t = @pdf.table(
+      [
+        [{:content => "Lorem ipsum dolor sit amet", :colspan => 3}],
+        ["Lorem ipsum dolor", "B", "C"]
+      ]
+    )
+
+    # Check that first is much wider than other two and other two are same.
+    expect(t.column_widths[0]).to be > 100
+    expect(t.column_widths[1]).to be < 50
+    expect(t.column_widths[2]).to be_within(0.01).of(t.column_widths[1])
+  end
+
   it "skips column numbers that have been col-spanned" do
     t = @pdf.table([["a", "b", {:content => "c", :colspan => 3}, "d"]])
     t.cells[0, 0].content.should == "a"


### PR DESCRIPTION
When cells under the colspan are shorter than the
spanning cell we want to make the cells under larger
so that in total they match the spanning cell.

However, if content widths were uneven this could
cause a cell to be made shorter than content, breaking
it. To avoid this the logic is changed to make sure
divide the extra width in such a way that only cells
which are made wider are changed and then all such
cells end up with the same width.