### PR TITLE
[Table] Fix header rendering on subsequent pages

### DIFF
--- a/lib/prawn/table/cell/text.rb
+++ b/lib/prawn/table/cell/text.rb
@@ -1,4 +1,4 @@
-# encoding: utf-8   
+# encoding: utf-8
 
 # text.rb: Text table cells.
 #
@@ -64,8 +64,11 @@ module Prawn
         # Draws the text content into its bounding box.
         #
         def draw_content
-          with_font do 
-            @pdf.move_down((@pdf.font.line_gap + @pdf.font.descender)/2)
+          with_font do
+            if @text_options[:valign] != :center
+              @pdf.move_down((@pdf.font.line_gap + @pdf.font.descender)/2)
+            end
+
             with_text_color do
               text_box(:width => spanned_content_width + FPTolerance,
                        :height => spanned_content_height + FPTolerance,
@@ -112,7 +115,7 @@ module Prawn
             yield
           end
         end
-        
+
         def text_box(extra_options={})
           if @text_options[:inline_format]
             options = @text_options.dup


### PR DESCRIPTION
Refactor how table headers are handled when a table spans multiple pages. Previously, headers on subsequent pages (not the first) could render incorrectly, particularly when `rowspan` was used in the table structure.

This change addresses the issue by:
- Removing the `add_header` method and the `@header_row` duplication logic.
- Dynamically tracking header cells and explicitly adding them to the `cells_this_page` collection during a page split.
- Ensuring that all header cell properties, including `rowspan` behavior, are correctly preserved and rendered at the top of new pages.
- Improving the clarity of page splitting conditions for better readability.